### PR TITLE
[Improve] Make build script more friendly to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ ds:
     dir: /dj
   project:
     # The default project name of dolphinscheduler
+    # You may need to create the project first in dolphinscheduler
     default: test_dj
   tenant:
     # Which tenant been used to submit script  
@@ -84,8 +85,8 @@ And the log will tell u anything you need to know.
 ```shell
 # start backend
 
-# for build code
-sh build.sh code
+# for build distribution
+sh build.sh dist
 
 # for build image
 sh build.sh image

--- a/build.sh
+++ b/build.sh
@@ -47,6 +47,9 @@ print_help() {
   echo "Arguments:"
   echo "          dist    Build an archived distribution and place the binary file in project home directory"
   echo "          image   Build a docker image."
+  echo ""
+  echo "Options:"
+  echo "          -h --help    Print help message."
 }
 
 # main
@@ -57,9 +60,22 @@ case "$1" in
 "image")
   build_image
   ;;
-*)
+"-h" | "--help")
   print_help
-  exit 1
+  exit 0
+  ;;
+*)
+  if [[ -z "$1" ]]; then
+    print_help
+    exit 0
+  else
+    echo "Invalid argument: $1"
+    echo ""
+    echo "See the following help messages:"
+    echo ""
+    print_help
+    exit 1
+  fi
   ;;
 esac
 set +


### PR DESCRIPTION
## Purpose of this pull request
When I build the project on my machine, I found the build script does not print help message correctly and also some other problems. So I modified the script to let the script seems more "friendly to use"

## Changes
1. Make script print help message correctly.
2. Add print help option to the script
3. When build docker image, Set image tag name using project version instead of specified version.
4. Modify README.md to fit script changes

## Check list

* [x] Code changed are covered with tests, or it does not need tests for reason:
* [x] No jar added
* [x] No other new features
