### PR TITLE
[Bugfix] Fix webui build 'assets' not included bug.

### DIFF
--- a/seatunnel-server/seatunnel-app/src/main/assembly/seatunnel-web.xml
+++ b/seatunnel-server/seatunnel-app/src/main/assembly/seatunnel-web.xml
@@ -45,7 +45,7 @@
         <fileSet>
             <directory>${basedir}/../../seatunnel-ui/dist</directory>
             <includes>
-                <include>*</include>
+                <include>**/**</include>
             </includes>
             <outputDirectory>dist</outputDirectory>
         </fileSet>


### PR DESCRIPTION
## Purpose of this pull request
Fix a bug.
I found the web-ui can not open after build and start. The reason is maven-assembly-plugin does NOT put all dist files in ui module to the archive.

## Check list

* [x] Code changed are covered with tests, or it does not need tests for reason:
* [x] No other jar added
* [x]  No new features
