### PR TITLE
[Bug] [Seatunnel-web] gc.log, nohup.out is created outside of logs directory

### DIFF
--- a/seatunnel-server/seatunnel-app/src/main/bin/seatunnel-backend-daemon.sh
+++ b/seatunnel-server/seatunnel-app/src/main/bin/seatunnel-backend-daemon.sh
@@ -39,9 +39,10 @@ start() {
 
   check
 
-  JAVA_OPTS="${JAVA_OPTS} -server -Xms1g -Xmx1g -Xmn512m -XX:+PrintGCDetails -Xloggc:gc.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=dump.hprof"
+  LOGDIR=${WORKDIR}/../logs
+  JAVA_OPTS="${JAVA_OPTS} -server -Xms1g -Xmx1g -Xmn512m -XX:+PrintGCDetails -Xloggc:${LOGDIR}/gc.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=dump.hprof"
   SPRING_OPTS="${SPRING_OPTS} -Dspring.config.name=application.yml -Dspring.config.location=classpath:application.yml"
-  JAVA_OPTS="${JAVA_OPTS} -Dseatunnel-web.logs.path=${WORKDIR}/../logs"
+  JAVA_OPTS="${JAVA_OPTS} -Dseatunnel-web.logs.path=${LOGDIR}"
   # check env JAVA_HOME
   if [ -z "$JAVA_HOME" ]; then
     echo "JAVA_HOME is not set"
@@ -52,7 +53,7 @@ start() {
   nohup $JAVA_HOME/bin/java $JAVA_OPTS \
   -cp "$WORKDIR/../conf":"$WORKDIR/../libs/*":"$WORKDIR/../datasource/*" \
   $SPRING_OPTS \
-  org.apache.seatunnel.app.SeatunnelApplication 2>&1 &
+  org.apache.seatunnel.app.SeatunnelApplication >> "${LOGDIR}/seatunnel.out" 2>&1 &
   echo "seatunnel started"
 }
 # stop


### PR DESCRIPTION

<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

## Check list

* [ ] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs

After fix below seatunnel-web start command creates logs,out file and gc files inside logs directory
sh bin/seatunnel-backend-daemon.sh start

