### PR TITLE
[Improvement][Seatunnel-web] Bump frontend-maven-plugin from 1.11.3 to 1.15.0 and slf4j.version from 1.7.25 to 1.7.36

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <commons-logging.version>1.2</commons-logging.version>
         <log4j.version>1.2.17</log4j.version>
         <log4j-core.version>2.17.1</log4j-core.version>
-        <slf4j.version>1.7.25</slf4j.version>
+        <slf4j.version>1.7.36</slf4j.version>
         <skip.spotless>false</skip.spotless>
     </properties>
 

--- a/seatunnel-web-dist/pom.xml
+++ b/seatunnel-web-dist/pom.xml
@@ -68,7 +68,7 @@
                     <plugin>
                         <groupId>com.github.eirslett</groupId>
                         <artifactId>frontend-maven-plugin</artifactId>
-                        <version>1.11.3</version>
+                        <version>1.15.0</version>
                         <configuration>
                             <workingDirectory>${project.basedir}/../seatunnel-ui</workingDirectory>
                         </configuration>
@@ -427,7 +427,7 @@
                     <plugin>
                         <groupId>com.github.eirslett</groupId>
                         <artifactId>frontend-maven-plugin</artifactId>
-                        <version>1.11.3</version>
+                        <version>1.15.0</version>
                         <configuration>
                             <workingDirectory>${project.basedir}/../seatunnel-ui</workingDirectory>
                         </configuration>

--- a/tools/dependencies/known-dependencies.txt
+++ b/tools/dependencies/known-dependencies.txt
@@ -52,7 +52,7 @@ scala-library-2.12.15.jar
 
 
 
-slf4j-api-1.7.25.jar
+slf4j-api-1.7.36.jar
 snakeyaml-1.29.jar
 spring-aop-5.3.20.jar
 spring-beans-5.3.20.jar
@@ -96,10 +96,10 @@ clickhouse-jdbc-0.3.2-patch11.jar
 commons-lang3-3.4.jar
 httpcore-4.4.13.jar
 httpmime-4.5.13.jar
-jcl-over-slf4j-1.7.25.jar
+jcl-over-slf4j-1.7.36.jar
 jcommander-1.81.jar
 log4j-api-2.17.1.jar
-log4j-over-slf4j-1.7.25.jar
+log4j-over-slf4j-1.7.36.jar
 log4j-to-slf4j-2.17.1.jar
 logback-classic-1.2.3.jar
 logback-core-1.2.3.jar


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request
Changed frontend-maven-plugin from 1.11.3 to 1.15.0 to download correct node package
Changed slf4j.version from 1.7.25 to 1.7.36 to remediate CVS


<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

## Check list

* [ ] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
