### PR TITLE
[Bug] [Seatunnel-web] seatunnel-web start and plugin download scripts by default do not have execute permission

### DIFF
--- a/seatunnel-web-dist/src/main/assembly/seatunnel-web-ci.xml
+++ b/seatunnel-web-dist/src/main/assembly/seatunnel-web-ci.xml
@@ -43,6 +43,7 @@
             <outputDirectory>script</outputDirectory>
         </fileSet>
         <fileSet>
+            <fileMode>755</fileMode>
             <directory>../seatunnel-server/seatunnel-app/src/main/bin</directory>
             <includes>
                 <include>*.sh</include>

--- a/seatunnel-web-dist/src/main/assembly/seatunnel-web.xml
+++ b/seatunnel-web-dist/src/main/assembly/seatunnel-web.xml
@@ -44,6 +44,7 @@
             <outputDirectory>script</outputDirectory>
         </fileSet>
         <fileSet>
+            <fileMode>755</fileMode>
             <directory>../seatunnel-server/seatunnel-app/src/main/bin</directory>
             <includes>
                 <include>*.sh</include>


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request
Changed the default permission to 755

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

## Check list

* [ ] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
