### PR TITLE
[Improvement][Seatunnel-web] Execute job REST API should be of type POST, not GET

### DIFF
--- a/seatunnel-server/seatunnel-app/src/main/java/org/apache/seatunnel/app/controller/JobExecutorController.java
+++ b/seatunnel-server/seatunnel-app/src/main/java/org/apache/seatunnel/app/controller/JobExecutorController.java
@@ -25,6 +25,7 @@ import org.apache.seatunnel.server.common.SeatunnelErrorEnum;
 import org.apache.seatunnel.server.common.SeatunnelException;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -46,8 +47,8 @@ public class JobExecutorController {
     @Resource IJobExecutorService jobExecutorService;
     @Resource private IJobInstanceService jobInstanceService;
 
-    @GetMapping("/execute")
-    @ApiOperation(value = "Execute synchronization tasks", httpMethod = "GET")
+    @PostMapping("/execute")
+    @ApiOperation(value = "Execute synchronization tasks", httpMethod = "POST")
     public Result<Long> jobExecutor(
             @ApiParam(value = "userId", required = true) @RequestAttribute("userId") Integer userId,
             @ApiParam(value = "jobDefineId", required = true) @RequestParam("jobDefineId")

--- a/seatunnel-ui/src/service/sync-task-definition/index.ts
+++ b/seatunnel-ui/src/service/sync-task-definition/index.ts
@@ -317,7 +317,7 @@ export function sqlModelInfo(taskId: string, pluginId: string, data: any): any {
 export function executeJob(jobDefineId: number): any {
   return axios({
     url: `/job/executor/execute?jobDefineId=${jobDefineId}`,
-    method: 'get',
+    method: 'post',
     headers: {
       'Content-Type': 'application/json;charset=UTF-8'
     },

--- a/seatunnel-web-it/src/test/java/org/apache/seatunnel/app/controller/JobExecutorControllerWrapper.java
+++ b/seatunnel-web-it/src/test/java/org/apache/seatunnel/app/controller/JobExecutorControllerWrapper.java
@@ -26,7 +26,10 @@ public class JobExecutorControllerWrapper extends SeatunnelWebTestingBase {
 
     public Result<Long> jobExecutor(Long jobDefineId) {
         String response =
-                sendRequest(urlWithParam("job/executor/execute?jobDefineId=" + jobDefineId));
+                sendRequest(
+                        urlWithParam("job/executor/execute?jobDefineId=" + jobDefineId),
+                        "{}",
+                        "POST");
         return JSONTestUtils.parseObject(response, new TypeReference<Result<Long>>() {});
     }
 


### PR DESCRIPTION
Changed /seatunnel/api/v1/job/executor/execute method from GET to POST
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

## Check list

* [ ] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
