### PR TITLE
[Feature] [Seatunnel-web] Add support to execute job with parameter through API.

### DIFF
--- a/seatunnel-server/seatunnel-app/src/main/java/org/apache/seatunnel/app/controller/JobExecutorController.java
+++ b/seatunnel-server/seatunnel-app/src/main/java/org/apache/seatunnel/app/controller/JobExecutorController.java
@@ -18,6 +18,7 @@
 package org.apache.seatunnel.app.controller;
 
 import org.apache.seatunnel.app.common.Result;
+import org.apache.seatunnel.app.domain.request.job.JobExecParam;
 import org.apache.seatunnel.app.domain.response.executor.JobExecutorRes;
 import org.apache.seatunnel.app.service.IJobExecutorService;
 import org.apache.seatunnel.app.service.IJobInstanceService;
@@ -27,6 +28,7 @@ import org.apache.seatunnel.server.common.SeatunnelException;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -52,8 +54,9 @@ public class JobExecutorController {
     public Result<Long> jobExecutor(
             @ApiParam(value = "userId", required = true) @RequestAttribute("userId") Integer userId,
             @ApiParam(value = "jobDefineId", required = true) @RequestParam("jobDefineId")
-                    Long jobDefineId) {
-        return jobExecutorService.jobExecute(userId, jobDefineId);
+                    Long jobDefineId,
+            @RequestBody(required = false) JobExecParam executeParam) {
+        return jobExecutorService.jobExecute(userId, jobDefineId, executeParam);
     }
 
     @GetMapping("/resource")
@@ -64,7 +67,7 @@ public class JobExecutorController {
             throws IOException {
         try {
             JobExecutorRes executeResource =
-                    jobInstanceService.createExecuteResource(userId, jobDefineId);
+                    jobInstanceService.createExecuteResource(userId, jobDefineId, null);
             return Result.success(executeResource);
         } catch (Exception e) {
             log.error("Get the resource for job executor error", e);

--- a/seatunnel-server/seatunnel-app/src/main/java/org/apache/seatunnel/app/domain/request/job/JobExecParam.java
+++ b/seatunnel-server/seatunnel-app/src/main/java/org/apache/seatunnel/app/domain/request/job/JobExecParam.java
@@ -14,17 +14,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.seatunnel.app.domain.request.job;
 
-package org.apache.seatunnel.app.service;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
-import org.apache.seatunnel.app.common.Result;
-import org.apache.seatunnel.app.domain.request.job.JobExecParam;
+import java.util.Map;
 
-public interface IJobExecutorService {
-
-    Result<Long> jobExecute(Integer userId, Long jobDefineId, JobExecParam executeParam);
-
-    Result<Void> jobPause(Integer userId, Long jobInstanceId);
-
-    Result<Void> jobStore(Integer userId, Long jobInstanceId);
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+// Job execution parameters
+public class JobExecParam {
+    // job name -> key -> value
+    private Map<String, String> env;
+    // task name -> key -> value
+    private Map<String, Map<String, String>> tasks;
+    // task name -> new datasource id
+    private Map<String, String> datasource;
 }

--- a/seatunnel-server/seatunnel-app/src/main/java/org/apache/seatunnel/app/service/IJobInstanceService.java
+++ b/seatunnel-server/seatunnel-app/src/main/java/org/apache/seatunnel/app/service/IJobInstanceService.java
@@ -19,6 +19,7 @@ package org.apache.seatunnel.app.service;
 
 import org.apache.seatunnel.app.dal.entity.JobLine;
 import org.apache.seatunnel.app.dal.entity.JobTask;
+import org.apache.seatunnel.app.domain.request.job.JobExecParam;
 import org.apache.seatunnel.app.domain.response.executor.JobExecutorRes;
 
 import lombok.NonNull;
@@ -26,9 +27,15 @@ import lombok.NonNull;
 import java.util.List;
 
 public interface IJobInstanceService {
-    JobExecutorRes createExecuteResource(@NonNull Integer userId, @NonNull Long jobDefineId);
+    JobExecutorRes createExecuteResource(
+            @NonNull Integer userId, @NonNull Long jobDefineId, JobExecParam executeParam);
 
-    String generateJobConfig(Long jobId, List<JobTask> tasks, List<JobLine> lines, String envStr);
+    String generateJobConfig(
+            Long jobId,
+            List<JobTask> tasks,
+            List<JobLine> lines,
+            String envStr,
+            JobExecParam executeParam);
 
     JobExecutorRes getExecuteResource(@NonNull Long jobEngineId);
 

--- a/seatunnel-server/seatunnel-app/src/main/java/org/apache/seatunnel/app/service/impl/JobExecutorServiceImpl.java
+++ b/seatunnel-server/seatunnel-app/src/main/java/org/apache/seatunnel/app/service/impl/JobExecutorServiceImpl.java
@@ -20,6 +20,7 @@ package org.apache.seatunnel.app.service.impl;
 import org.apache.seatunnel.app.common.Result;
 import org.apache.seatunnel.app.dal.dao.IJobInstanceDao;
 import org.apache.seatunnel.app.dal.entity.JobInstance;
+import org.apache.seatunnel.app.domain.request.job.JobExecParam;
 import org.apache.seatunnel.app.domain.response.engine.Engine;
 import org.apache.seatunnel.app.domain.response.executor.JobExecutorRes;
 import org.apache.seatunnel.app.service.IJobExecutorService;
@@ -64,10 +65,10 @@ public class JobExecutorServiceImpl implements IJobExecutorService {
     @Resource private IJobInstanceDao jobInstanceDao;
 
     @Override
-    public Result<Long> jobExecute(Integer userId, Long jobDefineId) {
+    public Result<Long> jobExecute(Integer userId, Long jobDefineId, JobExecParam executeParam) {
 
         JobExecutorRes executeResource =
-                jobInstanceService.createExecuteResource(userId, jobDefineId);
+                jobInstanceService.createExecuteResource(userId, jobDefineId, executeParam);
         String jobConfig = executeResource.getJobConfig();
 
         String configFile = writeJobConfigIntoConfFile(jobConfig, jobDefineId);

--- a/seatunnel-server/seatunnel-app/src/main/java/org/apache/seatunnel/app/service/impl/JobTaskServiceImpl.java
+++ b/seatunnel-server/seatunnel-app/src/main/java/org/apache/seatunnel/app/service/impl/JobTaskServiceImpl.java
@@ -267,7 +267,7 @@ public class JobTaskServiceImpl extends SeatunnelBaseServiceImpl implements IJob
             }
             // check the config can be generated
             jobInstanceService.generateJobConfig(
-                    version.getJobId(), tasks, lines, version.getEnv());
+                    version.getJobId(), tasks, lines, version.getEnv(), null);
             // TODO check schema output and input matched
         } catch (SeaTunnelException e) {
             log.error(ExceptionUtils.getMessage(e));

--- a/seatunnel-server/seatunnel-app/src/main/java/org/apache/seatunnel/app/utils/JobExecParamUtil.java
+++ b/seatunnel-server/seatunnel-app/src/main/java/org/apache/seatunnel/app/utils/JobExecParamUtil.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seatunnel.app.utils;
+
+import org.apache.seatunnel.shade.com.typesafe.config.Config;
+import org.apache.seatunnel.shade.com.typesafe.config.ConfigValueFactory;
+
+import org.apache.seatunnel.app.dal.entity.JobTask;
+import org.apache.seatunnel.app.domain.request.job.JobExecParam;
+
+import java.util.List;
+import java.util.Map;
+
+public class JobExecParamUtil {
+
+    public static Config updateEnvConfig(JobExecParam jobExecParam, Config envConfig) {
+        if (jobExecParam == null || jobExecParam.getEnv() == null) {
+            return envConfig;
+        }
+        return updateConfig(envConfig, jobExecParam.getEnv());
+    }
+
+    private static Config updateConfig(Config config, Map<String, String> properties) {
+        for (Map.Entry<String, String> entry : properties.entrySet()) {
+            config =
+                    config.withValue(
+                            entry.getKey(), ConfigValueFactory.fromAnyRef(entry.getValue()));
+        }
+        return config;
+    }
+
+    public static Config updateTaskConfig(
+            JobExecParam jobExecParam, Config taskConfig, String taskName) {
+        if (jobExecParam == null
+                || jobExecParam.getTasks() == null
+                || jobExecParam.getTasks().get(taskName) == null) {
+            return taskConfig;
+        }
+        return updateConfig(taskConfig, jobExecParam.getTasks().get(taskName));
+    }
+
+    public static Config updateQueryTaskConfig(
+            JobExecParam jobExecParam, Config taskConfig, String taskName) {
+        if (jobExecParam == null
+                || jobExecParam.getTasks() == null
+                || jobExecParam.getTasks().get(taskName) == null) {
+            return taskConfig;
+        }
+        String query = jobExecParam.getTasks().get(taskName).get("query");
+        if (query != null) {
+            return taskConfig.withValue("query", ConfigValueFactory.fromAnyRef(query));
+        }
+        return taskConfig;
+    }
+
+    public static void updateDataSource(JobExecParam jobExecParam, List<JobTask> tasks) {
+        if (jobExecParam == null || jobExecParam.getDatasource() == null) {
+            return;
+        }
+        // Check current user has permission to access the datasource
+        jobExecParam
+                .getDatasource()
+                .forEach(
+                        (taskName, datasourceId) -> {
+                            tasks.stream()
+                                    .filter(task -> task.getName().equals(taskName))
+                                    .findFirst()
+                                    .ifPresent(
+                                            task ->
+                                                    task.setDataSourceId(
+                                                            Long.parseLong(datasourceId)));
+                        });
+    }
+}

--- a/seatunnel-web-it/src/test/java/org/apache/seatunnel/app/controller/JobExecutorControllerWrapper.java
+++ b/seatunnel-web-it/src/test/java/org/apache/seatunnel/app/controller/JobExecutorControllerWrapper.java
@@ -18,7 +18,9 @@ package org.apache.seatunnel.app.controller;
 
 import org.apache.seatunnel.app.common.Result;
 import org.apache.seatunnel.app.common.SeatunnelWebTestingBase;
+import org.apache.seatunnel.app.domain.request.job.JobExecParam;
 import org.apache.seatunnel.app.utils.JSONTestUtils;
+import org.apache.seatunnel.app.utils.JSONUtils;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 
@@ -29,6 +31,16 @@ public class JobExecutorControllerWrapper extends SeatunnelWebTestingBase {
                 sendRequest(
                         urlWithParam("job/executor/execute?jobDefineId=" + jobDefineId),
                         "{}",
+                        "POST");
+        return JSONTestUtils.parseObject(response, new TypeReference<Result<Long>>() {});
+    }
+
+    public Result<Long> jobExecutor(Long jobDefineId, JobExecParam jobExecParam) {
+        String requestBody = JSONUtils.toPrettyJsonString(jobExecParam);
+        String response =
+                sendRequest(
+                        urlWithParam("job/executor/execute?jobDefineId=" + jobDefineId),
+                        requestBody,
                         "POST");
         return JSONTestUtils.parseObject(response, new TypeReference<Result<Long>>() {});
     }

--- a/seatunnel-web-it/src/test/java/org/apache/seatunnel/app/controller/SeatunnelDatasourceControllerWrapper.java
+++ b/seatunnel-web-it/src/test/java/org/apache/seatunnel/app/controller/SeatunnelDatasourceControllerWrapper.java
@@ -46,6 +46,13 @@ public class SeatunnelDatasourceControllerWrapper extends SeatunnelWebTestingBas
         return result.getData();
     }
 
+    public String createMysqlDatasource(String datasourceName) {
+        DatasourceReq req = getMysqlDatasource(datasourceName);
+        Result<String> result = createDatasource(req);
+        assertTrue(result.isSuccess());
+        return result.getData();
+    }
+
     public DatasourceReq getFakeSourceDatasourceReq(String datasourceName) {
         DatasourceReq req = new DatasourceReq();
         req.setDatasourceName(datasourceName);
@@ -103,5 +110,15 @@ public class SeatunnelDatasourceControllerWrapper extends SeatunnelWebTestingBas
                                 baseUrl, searchVal, pluginName, pageNo, pageSize));
         return JSONTestUtils.parseObject(
                 response, new TypeReference<Result<PageInfo<DatasourceRes>>>() {});
+    }
+
+    public DatasourceReq getMysqlDatasource(String datasourceName) {
+        DatasourceReq req = new DatasourceReq();
+        req.setDatasourceName(datasourceName);
+        req.setPluginName("JDBC-Mysql");
+        req.setDescription(datasourceName + " description");
+        req.setDatasourceConfig(
+                "{\"url\":\"jdbc:mysql://localhost:3306/test?useSSL=false&useUnicode=true&characterEncoding=utf-8&allowMultiQueries=true&allowPublicKeyRetrieval=true\",\"driver\":\"com.mysql.cj.jdbc.Driver\",\"user\":\"someUser\",\"password\":\"somePassword\"}");
+        return req;
     }
 }

--- a/seatunnel-web-it/src/test/java/org/apache/seatunnel/app/test/JobExecutorControllerTest.java
+++ b/seatunnel-web-it/src/test/java/org/apache/seatunnel/app/test/JobExecutorControllerTest.java
@@ -18,7 +18,13 @@ package org.apache.seatunnel.app.test;
 
 import org.apache.seatunnel.app.common.Result;
 import org.apache.seatunnel.app.common.SeaTunnelWebCluster;
+import org.apache.seatunnel.app.controller.JobControllerWrapper;
 import org.apache.seatunnel.app.controller.JobExecutorControllerWrapper;
+import org.apache.seatunnel.app.controller.SeatunnelDatasourceControllerWrapper;
+import org.apache.seatunnel.app.domain.request.datasource.DatasourceReq;
+import org.apache.seatunnel.app.domain.request.job.JobCreateReq;
+import org.apache.seatunnel.app.domain.request.job.JobExecParam;
+import org.apache.seatunnel.app.domain.request.job.PluginConfig;
 import org.apache.seatunnel.app.domain.response.metrics.JobPipelineDetailMetricsRes;
 import org.apache.seatunnel.app.utils.JobUtils;
 
@@ -26,20 +32,30 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class JobExecutorControllerTest {
     private static final SeaTunnelWebCluster seaTunnelWebCluster = new SeaTunnelWebCluster();
     private static JobExecutorControllerWrapper jobExecutorControllerWrapper;
     private static final String uniqueId = "_" + System.currentTimeMillis();
+    private static SeatunnelDatasourceControllerWrapper seatunnelDatasourceControllerWrapper;
+    private static JobControllerWrapper jobControllerWrapper;
 
     @BeforeAll
     public static void setUp() {
         seaTunnelWebCluster.start();
         jobExecutorControllerWrapper = new JobExecutorControllerWrapper();
+        seatunnelDatasourceControllerWrapper = new SeatunnelDatasourceControllerWrapper();
+        jobControllerWrapper = new JobControllerWrapper();
     }
 
     @Test
@@ -58,6 +74,166 @@ public class JobExecutorControllerTest {
     }
 
     @Test
+    public void executeJobWithParameters() {
+        String jobName = "execJobWithParam" + uniqueId;
+        long jobVersionId = JobUtils.createJob(jobName);
+        Result<Long> result = jobExecutorControllerWrapper.jobExecutor(jobVersionId);
+        assertTrue(result.isSuccess());
+        assertTrue(result.getData() > 0);
+        Result<List<JobPipelineDetailMetricsRes>> listResult =
+                JobUtils.waitForJobCompletion(result.getData());
+        assertEquals(1, listResult.getData().size());
+        assertEquals("FINISHED", listResult.getData().get(0).getStatus());
+        assertEquals(5, listResult.getData().get(0).getReadRowCount());
+        assertEquals(5, listResult.getData().get(0).getWriteRowCount());
+        String generatedJobFile = getGenerateJobFile(String.valueOf(jobVersionId));
+        assertTrue(generatedJobFile.contains("\"is_regex\"=\"false\""));
+        assertTrue(generatedJobFile.contains("\"log.print.delay.ms\"=\"100\""));
+
+        JobExecParam jobExecParam = new JobExecParam();
+
+        Map<String, String> envConf = new HashMap<>();
+        envConf.put("job.name", "executeJobWithParameters");
+        jobExecParam.setEnv(envConf);
+        Map<String, Map<String, String>> tasks = new HashMap<>();
+        jobExecParam.setTasks(tasks);
+
+        int numberOfRecords = 100;
+        Map<String, String> task1Config = new HashMap<>();
+        task1Config.put("row.num", String.valueOf(numberOfRecords));
+        tasks.put("source-fakesource", task1Config);
+
+        Map<String, String> task2Config = new HashMap<>();
+        task2Config.put("replace_first", "true");
+        task2Config.put("is_regex", "true");
+        tasks.put("transform-replace", task2Config);
+
+        Map<String, String> task3Config = new HashMap<>();
+        task3Config.put("log.print.delay.ms", "99");
+        tasks.put("sink-console", task3Config);
+
+        result = jobExecutorControllerWrapper.jobExecutor(jobVersionId, jobExecParam);
+        assertTrue(result.isSuccess());
+        assertTrue(result.getData() > 0);
+        listResult = JobUtils.waitForJobCompletion(result.getData());
+        assertEquals(1, listResult.getData().size());
+        assertEquals("FINISHED", listResult.getData().get(0).getStatus());
+        assertEquals(numberOfRecords, listResult.getData().get(0).getReadRowCount());
+        assertEquals(numberOfRecords, listResult.getData().get(0).getWriteRowCount());
+
+        // Do few validations on the generated job file
+        generatedJobFile = getGenerateJobFile(String.valueOf(jobVersionId));
+        assertTrue(generatedJobFile.contains("\"is_regex\"=\"true\""));
+        assertTrue(generatedJobFile.contains("\"replace_first\"=\"true\""));
+        // database properties except query can not be updated
+        assertFalse(generatedJobFile.contains("\"log.print.delay.ms\"=\"99\""));
+        assertTrue(generatedJobFile.contains("\"job.name\"=executeJobWithParameters"));
+    }
+
+    @Test
+    public void executeJobWithParameters_AllowQueryUpdate() {
+        String jobName = "execJobUpdateQuery" + uniqueId;
+        JobCreateReq jobCreateReq = JobUtils.populateMySQLJobCreateReqFromFile();
+        jobCreateReq.getJobConfig().setName(jobName);
+        jobCreateReq.getJobConfig().setDescription(jobName + " description");
+        String datasourceName = "execJobUpdateQuery_db" + uniqueId;
+        String mysqlDatasourceId =
+                seatunnelDatasourceControllerWrapper.createMysqlDatasource(datasourceName);
+        for (PluginConfig pluginConfig : jobCreateReq.getPluginConfigs()) {
+            pluginConfig.setDataSourceId(Long.parseLong(mysqlDatasourceId));
+        }
+        Result<Long> job = jobControllerWrapper.createJob(jobCreateReq);
+        assertTrue(job.isSuccess());
+        Long jobVersionId = job.getData();
+        Result<Long> result = jobExecutorControllerWrapper.jobExecutor(jobVersionId);
+        // Fails because of the wrong credentials of the database.
+        assertFalse(result.isSuccess());
+        String generatedJobFile = getGenerateJobFile(String.valueOf(jobVersionId));
+        assertTrue(
+                generatedJobFile.contains(
+                        "query=\"SELECT `name`, `age` FROM `test`.`test_table`\""));
+        assertTrue(generatedJobFile.contains("user=someUser"));
+        assertTrue(generatedJobFile.contains("password=somePassword"));
+
+        JobExecParam jobExecParam = new JobExecParam();
+        Map<String, Map<String, String>> tasks = new HashMap<>();
+        jobExecParam.setTasks(tasks);
+
+        Map<String, String> task1Config = new HashMap<>();
+        task1Config.put("query", "SELECT `name`, `age` FROM `test`.`test_table` LIMIT 10");
+        task1Config.put("user", "otherUser");
+        task1Config.put("password", "otherPassword");
+        tasks.put("mysql_source_1", task1Config);
+
+        result = jobExecutorControllerWrapper.jobExecutor(jobVersionId, jobExecParam);
+        assertFalse(result.isSuccess());
+        // query should be changed but other database details should not be changed,
+        generatedJobFile = getGenerateJobFile(String.valueOf(jobVersionId));
+        assertTrue(
+                generatedJobFile.contains(
+                        "query=\"SELECT `name`, `age` FROM `test`.`test_table` LIMIT 10\""));
+        assertTrue(generatedJobFile.contains("user=someUser"));
+        assertTrue(generatedJobFile.contains("password=somePassword"));
+    }
+
+    @Test
+    public void executeJobWithParameters_ChangeDatabase() {
+        String jobName = "execJobChangeDatabase" + uniqueId;
+        JobCreateReq jobCreateReq = JobUtils.populateMySQLJobCreateReqFromFile();
+        jobCreateReq.getJobConfig().setName(jobName);
+        jobCreateReq.getJobConfig().setDescription(jobName + " description");
+        String datasourceName = "execJobChangeDatabase_db_1" + uniqueId;
+        String mysqlDatasourceId =
+                seatunnelDatasourceControllerWrapper.createMysqlDatasource(datasourceName);
+        for (PluginConfig pluginConfig : jobCreateReq.getPluginConfigs()) {
+            pluginConfig.setDataSourceId(Long.parseLong(mysqlDatasourceId));
+        }
+        Result<Long> job = jobControllerWrapper.createJob(jobCreateReq);
+        assertTrue(job.isSuccess());
+        Long jobVersionId = job.getData();
+        Result<Long> result = jobExecutorControllerWrapper.jobExecutor(jobVersionId);
+        // Fails because of the wrong credentials of the database.
+        assertFalse(result.isSuccess());
+        String generatedJobFile = getGenerateJobFile(String.valueOf(jobVersionId));
+        assertTrue(
+                generatedJobFile.contains(
+                        "query=\"SELECT `name`, `age` FROM `test`.`test_table`\""));
+        assertTrue(generatedJobFile.contains("user=someUser"));
+        assertTrue(generatedJobFile.contains("password=somePassword"));
+
+        String datasourceName2 = "execJobChangeDatabase_db_2" + uniqueId;
+        DatasourceReq req = getDatasourceReq(datasourceName2);
+
+        Result<String> datasource = seatunnelDatasourceControllerWrapper.createDatasource(req);
+        assertTrue(datasource.isSuccess());
+        JobExecParam jobExecParam = new JobExecParam();
+        Map<String, String> dbConfigs = new HashMap<>();
+        jobExecParam.setDatasource(dbConfigs);
+
+        dbConfigs.put("mysql_source_1", datasource.getData());
+
+        result = jobExecutorControllerWrapper.jobExecutor(jobVersionId, jobExecParam);
+        assertFalse(result.isSuccess());
+        // query should be changed but other database details should not be changed,
+        generatedJobFile = getGenerateJobFile(String.valueOf(jobVersionId));
+        assertTrue(
+                generatedJobFile.contains(
+                        "query=\"SELECT `name`, `age` FROM `test`.`test_table`\""));
+        assertTrue(generatedJobFile.contains("user=someUser2"));
+        assertTrue(generatedJobFile.contains("password=somePassword2"));
+    }
+
+    private static DatasourceReq getDatasourceReq(String datasourceName2) {
+        DatasourceReq req = new DatasourceReq();
+        req.setDatasourceName(datasourceName2);
+        req.setPluginName("JDBC-Mysql");
+        req.setDescription(datasourceName2 + " description");
+        req.setDatasourceConfig(
+                "{\"url\":\"jdbc:mysql://localhost:3306/test?useSSL=false&useUnicode=true&characterEncoding=utf-8&allowMultiQueries=true&allowPublicKeyRetrieval=true\",\"driver\":\"com.mysql.cj.jdbc.Driver\",\"user\":\"someUser2\",\"password\":\"somePassword2\"}");
+        return req;
+    }
+
+    @Test
     public void restoreJob_shouldReturnSuccess_whenValidRequest() {
         String jobName = "jobRestore" + uniqueId;
         long jobVersionId = JobUtils.createJob(jobName);
@@ -70,5 +246,16 @@ public class JobExecutorControllerTest {
     @AfterAll
     public static void tearDown() {
         seaTunnelWebCluster.stop();
+    }
+
+    private String getGenerateJobFile(String jobId) {
+        String filePath = "profile/" + jobId + ".conf";
+        String jsonContent;
+        try {
+            jsonContent = new String(Files.readAllBytes(Paths.get(filePath)));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return jsonContent;
     }
 }

--- a/seatunnel-web-it/src/test/java/org/apache/seatunnel/app/utils/JobUtils.java
+++ b/seatunnel-web-it/src/test/java/org/apache/seatunnel/app/utils/JobUtils.java
@@ -24,10 +24,14 @@ import org.apache.seatunnel.app.controller.JobTaskControllerWrapper;
 import org.apache.seatunnel.app.controller.SeatunnelDatasourceControllerWrapper;
 import org.apache.seatunnel.app.domain.request.job.Edge;
 import org.apache.seatunnel.app.domain.request.job.JobConfig;
+import org.apache.seatunnel.app.domain.request.job.JobCreateReq;
 import org.apache.seatunnel.app.domain.request.job.JobDAG;
 import org.apache.seatunnel.app.domain.response.job.JobTaskCheckRes;
 import org.apache.seatunnel.app.domain.response.metrics.JobPipelineDetailMetricsRes;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -137,5 +141,16 @@ public class JobUtils {
                 jobTaskControllerWrapper.saveJobDAG(jobVersionId, jobDAG);
         assertTrue(jobTaskCheckResResult.isSuccess());
         return jobVersionId;
+    }
+
+    public static JobCreateReq populateMySQLJobCreateReqFromFile() {
+        String filePath = "src/test/resources/jobs/mysql_source_mysql_sink.json";
+        String jsonContent;
+        try {
+            jsonContent = new String(Files.readAllBytes(Paths.get(filePath)));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return JSONTestUtils.parseObject(jsonContent, JobCreateReq.class);
     }
 }

--- a/seatunnel-web-it/src/test/resources/jobs/mysql_source_mysql_sink.json
+++ b/seatunnel-web-it/src/test/resources/jobs/mysql_source_mysql_sink.json
@@ -1,0 +1,106 @@
+{
+  "jobConfig": {
+    "name": "mysql_source_mysql_sink",
+    "description": "mysql_source_mysql_sink description",
+    "engine": "SeaTunnel",
+    "env": {
+      "job.mode": "BATCH",
+      "job.name": "SeaTunnel_Job",
+      "jars": "",
+      "checkpoint.interval": "",
+      "checkpoint.timeout": "",
+      "read_limit.rows_per_second": "",
+      "read_limit.bytes_per_second": "",
+      "custom_parameters": ""
+    }
+  },
+  "pluginConfigs": [
+    {
+      "pluginId": "1724412762429155",
+      "name": "mysql_source_1",
+      "type": "SOURCE",
+      "connectorType": null,
+      "tableOption": {
+        "databases": [
+          "test"
+        ],
+        "tables": [
+          "test_table"
+        ]
+      },
+      "selectTableFields": {
+        "tableFields": [
+          "name",
+          "age"
+        ],
+        "all": true
+      },
+      "dataSourceId": 14717667385504,
+      "sceneMode": "SINGLE_TABLE",
+      "config": "{\"query\":\"\",\"connection_check_timeout_sec\":30,\"fetch_size\":\"\",\"partition_column\":\"\",\"partition_upper_bound\":\"\",\"partition_lower_bound\":\"\",\"partition_num\":\"\",\"compatible_mode\":\"\",\"properties\":\"\",\"table_path\":\"\",\"where_condition\":\"\",\"table_list\":\"\",\"split.size\":8096,\"split.even-distribution.factor.upper-bound\":100,\"split.even-distribution.factor.lower-bound\":0.05,\"split.sample-sharding.threshold\":1000,\"split.inverse-sampling.rate\":1000,\"parallelism\":1}",
+      "outputSchema": [
+        {
+          "fields": [
+            {
+              "type": "LONGTEXT",
+              "name": "name",
+              "comment": "",
+              "primaryKey": false,
+              "defaultValue": null,
+              "nullable": false,
+              "properties": null,
+              "unSupport": false,
+              "outputDataType": "STRING"
+            },
+            {
+              "type": "INT",
+              "name": "age",
+              "comment": "",
+              "primaryKey": false,
+              "defaultValue": null,
+              "nullable": false,
+              "properties": null,
+              "unSupport": false,
+              "outputDataType": "INT"
+            }
+          ],
+          "tableName": "test_table",
+          "database": "test"
+        }
+      ],
+      "transformOptions": {}
+    },
+    {
+      "pluginId": "17244128298414uc",
+      "name": "mysql_sink_1",
+      "type": "SINK",
+      "connectorType": null,
+      "tableOption": {
+        "databases": [
+          "test"
+        ],
+        "tables": [
+          "test_table"
+        ]
+      },
+      "selectTableFields": {
+        "tableFields": [
+          "name",
+          "age"
+        ],
+        "all": true
+      },
+      "dataSourceId": 14717667385504,
+      "config": "{\"query\":\"\",\"schema_save_mode\":\"CREATE_SCHEMA_WHEN_NOT_EXIST\",\"data_save_mode\":\"APPEND_DATA\",\"custom_sql\":\"\",\"connection_check_timeout_sec\":30,\"batch_size\":1000,\"is_exactly_once\":\"false\",\"xa_data_source_class_name\":\"\",\"max_commit_attempts\":3,\"transaction_timeout_sec\":-1,\"max_retries\":\"1\",\"auto_commit\":\"true\",\"support_upsert_by_query_primary_key_exist\":\"false\",\"primary_keys\":\"\",\"compatible_mode\":\"\",\"multi_table_sink_replica\":1}",
+      "transformOptions": {}
+    }
+  ],
+  "jobDAG": {
+    "edges": [
+      {
+        "inputPluginId": "mysql_source_1",
+        "targetPluginId": "mysql_sink_1"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Added support to execute job with paramters.
Here is the sample job execution parameters.Every aspect the job can be changed at execution.
{
"env": {
"ENV_VAR1": "value1",
"ENV_VAR2": "value2"
},
"tasks": {
"task1_name": {
"param1": "value1",
"param2": "value2"
},
"task2_name": {
"param1": "value3",
"param2": "value4"
}
},
"datasource": {
"task1_name": "123_datasource_id",
"task2_name": "456_datasource_id"
}
}
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

## Check list

* [ ] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
