### PR TITLE
[Improvement] [Seatunnel-web] Add API to get job execution status.

### DIFF
--- a/seatunnel-server/seatunnel-app/src/main/java/org/apache/seatunnel/app/controller/JobExecutorController.java
+++ b/seatunnel-server/seatunnel-app/src/main/java/org/apache/seatunnel/app/controller/JobExecutorController.java
@@ -18,10 +18,13 @@
 package org.apache.seatunnel.app.controller;
 
 import org.apache.seatunnel.app.common.Result;
+import org.apache.seatunnel.app.domain.dto.job.SeaTunnelJobInstanceDto;
 import org.apache.seatunnel.app.domain.request.job.JobExecParam;
+import org.apache.seatunnel.app.domain.response.executor.JobExecutionStatus;
 import org.apache.seatunnel.app.domain.response.executor.JobExecutorRes;
 import org.apache.seatunnel.app.service.IJobExecutorService;
 import org.apache.seatunnel.app.service.IJobInstanceService;
+import org.apache.seatunnel.app.service.ITaskInstanceService;
 import org.apache.seatunnel.server.common.SeatunnelErrorEnum;
 import org.apache.seatunnel.server.common.SeatunnelException;
 
@@ -48,6 +51,7 @@ public class JobExecutorController {
 
     @Resource IJobExecutorService jobExecutorService;
     @Resource private IJobInstanceService jobInstanceService;
+    @Resource private ITaskInstanceService<SeaTunnelJobInstanceDto> taskInstanceService;
 
     @PostMapping("/execute")
     @ApiOperation(value = "Execute synchronization tasks", httpMethod = "POST")
@@ -87,5 +91,21 @@ public class JobExecutorController {
             @ApiParam(value = "userId", required = true) @RequestAttribute("userId") Integer userId,
             @ApiParam(value = "jobInstanceId", required = true) @RequestParam Long jobInstanceId) {
         return jobExecutorService.jobStore(userId, jobInstanceId);
+    }
+
+    @GetMapping("/status")
+    @ApiOperation(value = "get job execution status", httpMethod = "GET")
+    Result<JobExecutionStatus> getJobExecutionStatus(
+            @ApiParam(value = "userId", required = true) @RequestAttribute("userId") Integer userId,
+            @ApiParam(value = "jobInstanceId", required = true) @RequestParam Long jobInstanceId) {
+        return taskInstanceService.getJobExecutionStatus(userId, jobInstanceId);
+    }
+
+    @GetMapping("/detail")
+    @ApiOperation(value = "get job execution status and some more details", httpMethod = "GET")
+    Result<SeaTunnelJobInstanceDto> getJobExecutionDetail(
+            @ApiParam(value = "userId", required = true) @RequestAttribute("userId") Integer userId,
+            @ApiParam(value = "jobInstanceId", required = true) @RequestParam Long jobInstanceId) {
+        return taskInstanceService.getJobExecutionDetail(userId, jobInstanceId);
     }
 }

--- a/seatunnel-server/seatunnel-app/src/main/java/org/apache/seatunnel/app/dal/dao/IJobInstanceDao.java
+++ b/seatunnel-server/seatunnel-app/src/main/java/org/apache/seatunnel/app/dal/dao/IJobInstanceDao.java
@@ -47,4 +47,6 @@ public interface IJobInstanceDao {
             String jobMode);
 
     List<JobInstance> getAllJobInstance(@NonNull List<Long> jobInstanceIdList);
+
+    JobInstance getJobExecutionStatus(@NonNull Long jobInstanceId);
 }

--- a/seatunnel-server/seatunnel-app/src/main/java/org/apache/seatunnel/app/dal/dao/impl/JobInstanceDaoImpl.java
+++ b/seatunnel-server/seatunnel-app/src/main/java/org/apache/seatunnel/app/dal/dao/impl/JobInstanceDaoImpl.java
@@ -88,4 +88,9 @@ public class JobInstanceDaoImpl implements IJobInstanceDao {
 
         return jobInstances;
     }
+
+    @Override
+    public JobInstance getJobExecutionStatus(@NonNull Long jobInstanceId) {
+        return jobInstanceMapper.getJobExecutionStatus(jobInstanceId);
+    }
 }

--- a/seatunnel-server/seatunnel-app/src/main/java/org/apache/seatunnel/app/dal/mapper/JobInstanceMapper.java
+++ b/seatunnel-server/seatunnel-app/src/main/java/org/apache/seatunnel/app/dal/mapper/JobInstanceMapper.java
@@ -37,4 +37,6 @@ public interface JobInstanceMapper extends BaseMapper<JobInstance> {
             @Param("endTime") Date endTime,
             @Param("jobDefineId") Long jobDefineId,
             @Param("jobMode") String jobMode);
+
+    JobInstance getJobExecutionStatus(@Param("jobInstanceId") Long jobInstanceId);
 }

--- a/seatunnel-server/seatunnel-app/src/main/java/org/apache/seatunnel/app/domain/response/executor/JobExecutionStatus.java
+++ b/seatunnel-server/seatunnel-app/src/main/java/org/apache/seatunnel/app/domain/response/executor/JobExecutionStatus.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.app.domain.response.executor;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class JobExecutionStatus {
+
+    private String jobStatus;
+
+    private String errorMessage;
+}

--- a/seatunnel-server/seatunnel-app/src/main/java/org/apache/seatunnel/app/service/ITaskInstanceService.java
+++ b/seatunnel-server/seatunnel-app/src/main/java/org/apache/seatunnel/app/service/ITaskInstanceService.java
@@ -18,6 +18,8 @@
 package org.apache.seatunnel.app.service;
 
 import org.apache.seatunnel.app.common.Result;
+import org.apache.seatunnel.app.domain.dto.job.SeaTunnelJobInstanceDto;
+import org.apache.seatunnel.app.domain.response.executor.JobExecutionStatus;
 import org.apache.seatunnel.app.utils.PageInfo;
 
 public interface ITaskInstanceService<T> {
@@ -32,4 +34,8 @@ public interface ITaskInstanceService<T> {
             String syncTaskType,
             Integer pageNo,
             Integer pageSize);
+
+    Result<JobExecutionStatus> getJobExecutionStatus(Integer userId, long jobInstanceId);
+
+    Result<SeaTunnelJobInstanceDto> getJobExecutionDetail(Integer userId, long jobInstanceId);
 }

--- a/seatunnel-server/seatunnel-app/src/main/resources/org/apache/seatunnel/app/dal/mapper/JobInstanceMapper.xml
+++ b/seatunnel-server/seatunnel-app/src/main/resources/org/apache/seatunnel/app/dal/mapper/JobInstanceMapper.xml
@@ -53,4 +53,9 @@
         </where>
         ORDER BY create_time DESC
     </select>
+    <select id="getJobExecutionStatus" resultType="org.apache.seatunnel.app.dal.entity.JobInstance">
+        SELECT `job_status`, `error_message`
+        FROM t_st_job_instance t
+        WHERE t.id = #{jobInstanceId}
+    </select>
 </mapper>

--- a/seatunnel-web-it/src/test/java/org/apache/seatunnel/app/controller/JobExecutorControllerWrapper.java
+++ b/seatunnel-web-it/src/test/java/org/apache/seatunnel/app/controller/JobExecutorControllerWrapper.java
@@ -18,7 +18,9 @@ package org.apache.seatunnel.app.controller;
 
 import org.apache.seatunnel.app.common.Result;
 import org.apache.seatunnel.app.common.SeatunnelWebTestingBase;
+import org.apache.seatunnel.app.domain.dto.job.SeaTunnelJobInstanceDto;
 import org.apache.seatunnel.app.domain.request.job.JobExecParam;
+import org.apache.seatunnel.app.domain.response.executor.JobExecutionStatus;
 import org.apache.seatunnel.app.domain.response.executor.JobExecutorRes;
 import org.apache.seatunnel.app.utils.JSONTestUtils;
 import org.apache.seatunnel.app.utils.JSONUtils;
@@ -62,5 +64,19 @@ public class JobExecutorControllerWrapper extends SeatunnelWebTestingBase {
         String response =
                 sendRequest(urlWithParam("job/executor/restore?jobInstanceId=" + jobInstanceId));
         return JSONTestUtils.parseObject(response, Result.class);
+    }
+
+    public Result<JobExecutionStatus> getJobExecutionStatus(Long jobInstanceId) {
+        String response =
+                sendRequest(urlWithParam("job/executor/status?jobInstanceId=" + jobInstanceId));
+        return JSONTestUtils.parseObject(
+                response, new TypeReference<Result<JobExecutionStatus>>() {});
+    }
+
+    public Result<SeaTunnelJobInstanceDto> getJobExecutionDetail(Long jobInstanceId) {
+        String response =
+                sendRequest(urlWithParam("job/executor/detail?jobInstanceId=" + jobInstanceId));
+        return JSONTestUtils.parseObject(
+                response, new TypeReference<Result<SeaTunnelJobInstanceDto>>() {});
     }
 }


### PR DESCRIPTION
Currently, there is no direct API to get job execution status.
Add following two APIs
/seatunnel/api/v1/job/executor/status --> this should return jobStatus and errorMessage
/seatunnel/api/v1/job/executor/detail --> this should return SeaTunnelJobInstanceDto which includes jobStatus, errorMessage and other details

Both APIs accept jobVersionId as the parameter
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

## Check list

* [ ] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
