### PR TITLE
[Bug] [Seatunnel-web] Job instance delete is not working

### DIFF
--- a/seatunnel-server/seatunnel-app/src/main/java/org/apache/seatunnel/app/controller/JobExecutorController.java
+++ b/seatunnel-server/seatunnel-app/src/main/java/org/apache/seatunnel/app/controller/JobExecutorController.java
@@ -28,6 +28,7 @@ import org.apache.seatunnel.app.service.ITaskInstanceService;
 import org.apache.seatunnel.server.common.SeatunnelErrorEnum;
 import org.apache.seatunnel.server.common.SeatunnelException;
 
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestAttribute;
@@ -107,5 +108,13 @@ public class JobExecutorController {
             @ApiParam(value = "userId", required = true) @RequestAttribute("userId") Integer userId,
             @ApiParam(value = "jobInstanceId", required = true) @RequestParam Long jobInstanceId) {
         return taskInstanceService.getJobExecutionDetail(userId, jobInstanceId);
+    }
+
+    @DeleteMapping("/delete")
+    @ApiOperation(value = "Deletes given job instance id", httpMethod = "DELETE")
+    Result<Void> deleteJobInstance(
+            @ApiParam(value = "userId", required = true) @RequestAttribute("userId") Integer userId,
+            @ApiParam(value = "jobInstanceId", required = true) @RequestParam Long jobInstanceId) {
+        return taskInstanceService.deleteJobInstanceById(userId, jobInstanceId);
     }
 }

--- a/seatunnel-server/seatunnel-app/src/main/java/org/apache/seatunnel/app/dal/dao/IJobInstanceDao.java
+++ b/seatunnel-server/seatunnel-app/src/main/java/org/apache/seatunnel/app/dal/dao/IJobInstanceDao.java
@@ -49,4 +49,6 @@ public interface IJobInstanceDao {
     List<JobInstance> getAllJobInstance(@NonNull List<Long> jobInstanceIdList);
 
     JobInstance getJobExecutionStatus(@NonNull Long jobInstanceId);
+
+    void deleteById(@NonNull Long jobInstanceId);
 }

--- a/seatunnel-server/seatunnel-app/src/main/java/org/apache/seatunnel/app/dal/dao/impl/JobInstanceDaoImpl.java
+++ b/seatunnel-server/seatunnel-app/src/main/java/org/apache/seatunnel/app/dal/dao/impl/JobInstanceDaoImpl.java
@@ -93,4 +93,9 @@ public class JobInstanceDaoImpl implements IJobInstanceDao {
     public JobInstance getJobExecutionStatus(@NonNull Long jobInstanceId) {
         return jobInstanceMapper.getJobExecutionStatus(jobInstanceId);
     }
+
+    @Override
+    public void deleteById(@NonNull Long jobInstanceId) {
+        jobInstanceMapper.deleteById(jobInstanceId);
+    }
 }

--- a/seatunnel-server/seatunnel-app/src/main/java/org/apache/seatunnel/app/service/ITaskInstanceService.java
+++ b/seatunnel-server/seatunnel-app/src/main/java/org/apache/seatunnel/app/service/ITaskInstanceService.java
@@ -38,4 +38,6 @@ public interface ITaskInstanceService<T> {
     Result<JobExecutionStatus> getJobExecutionStatus(Integer userId, long jobInstanceId);
 
     Result<SeaTunnelJobInstanceDto> getJobExecutionDetail(Integer userId, long jobInstanceId);
+
+    Result<Void> deleteJobInstanceById(Integer userId, long jobInstanceId);
 }

--- a/seatunnel-server/seatunnel-app/src/main/java/org/apache/seatunnel/app/service/impl/TaskInstanceServiceImpl.java
+++ b/seatunnel-server/seatunnel-app/src/main/java/org/apache/seatunnel/app/service/impl/TaskInstanceServiceImpl.java
@@ -241,4 +241,10 @@ public class TaskInstanceServiceImpl implements ITaskInstanceService<SeaTunnelJo
         dto.setErrorMessage(jobInstance.getErrorMessage());
         return dto;
     }
+
+    @Override
+    public Result<Void> deleteJobInstanceById(Integer userId, long jobInstanceId) {
+        jobInstanceDao.deleteById(jobInstanceId);
+        return Result.success();
+    }
 }

--- a/seatunnel-ui/src/service/sync-task-instance/index.ts
+++ b/seatunnel-ui/src/service/sync-task-instance/index.ts
@@ -85,7 +85,7 @@ export function hanldleRecoverJob(id: number): any {
 
 export function hanldleDelJob(id: number): any {
   return axios({
-    url: `/job/executor/del?jobInstanceId=${id}`,
-    method: 'get'
+    url: `/job/executor/delete?jobInstanceId=${id}`,
+    method: 'delete'
   })
 }

--- a/seatunnel-ui/src/views/task/synchronization-instance/use-sync-task.ts
+++ b/seatunnel-ui/src/views/task/synchronization-instance/use-sync-task.ts
@@ -180,10 +180,7 @@ export function useSyncTask(syncTaskType = 'BATCH') {
               isDelete: true,
               text: t('project.synchronization_instance.delete'),
               icon: h(DeleteOutlined),
-              onClick: (row) => void handleDel(row.id),
-              onPositiveClick: () => {
-                console.log('123')
-              },
+              onPositiveClick: (row) => void handleDel(row.id),
               positiveText: t('project.synchronization_instance.confirm'),
               popTips: t('project.synchronization_instance.delete_confirm')
             }
@@ -226,6 +223,7 @@ export function useSyncTask(syncTaskType = 'BATCH') {
   const handleDel = (id: number) => {
     hanldleDelJob(id).then(() => {
       message.success(t('common.success_tips'))
+      getList()
     })
   }
 

--- a/seatunnel-web-it/src/test/java/org/apache/seatunnel/app/controller/JobExecutorControllerWrapper.java
+++ b/seatunnel-web-it/src/test/java/org/apache/seatunnel/app/controller/JobExecutorControllerWrapper.java
@@ -79,4 +79,13 @@ public class JobExecutorControllerWrapper extends SeatunnelWebTestingBase {
         return JSONTestUtils.parseObject(
                 response, new TypeReference<Result<SeaTunnelJobInstanceDto>>() {});
     }
+
+    public Result<Void> deleteJobInstance(long jobInstanceId) {
+        String response =
+                sendRequest(
+                        urlWithParam("job/executor/delete?jobInstanceId=" + jobInstanceId),
+                        null,
+                        "DELETE");
+        return JSONTestUtils.parseObject(response, Result.class);
+    }
 }

--- a/seatunnel-web-it/src/test/java/org/apache/seatunnel/app/test/JobExecutorControllerTest.java
+++ b/seatunnel-web-it/src/test/java/org/apache/seatunnel/app/test/JobExecutorControllerTest.java
@@ -317,6 +317,36 @@ public class JobExecutorControllerTest {
         assertEquals(404, jobExecutionDetailResult2.getCode());
     }
 
+    @Test
+    public void testJobInstanceDelete() {
+        String jobName = "jobInstanceDelete" + uniqueId;
+        long jobVersionId = JobTestingUtils.createJob(jobName);
+        Result<Long> result = jobExecutorControllerWrapper.jobExecutor(jobVersionId);
+        assertTrue(result.isSuccess());
+        assertTrue(result.getData() > 0);
+        Long jobInstanceId = result.getData();
+        JobTestingUtils.waitForJobCompletion(jobInstanceId);
+        Result<SeaTunnelJobInstanceDto> jobExecutionDetailResult =
+                jobExecutorControllerWrapper.getJobExecutionDetail(jobInstanceId);
+        assertTrue(jobExecutionDetailResult.isSuccess());
+        assertNotNull(jobExecutionDetailResult.getData());
+
+        // Delete should be success
+        Result<Void> deleteResult = jobExecutorControllerWrapper.deleteJobInstance(jobInstanceId);
+        assertTrue(deleteResult.isSuccess());
+
+        // After delete job instance should not be found
+        jobExecutionDetailResult =
+                jobExecutorControllerWrapper.getJobExecutionDetail(jobInstanceId);
+        assertFalse(jobExecutionDetailResult.isSuccess());
+        assertEquals(404, jobExecutionDetailResult.getCode());
+
+        // Delete job instance which do not exist
+        deleteResult = jobExecutorControllerWrapper.deleteJobInstance(jobInstanceId);
+        // should be success as there is nothing to delete
+        assertTrue(deleteResult.isSuccess());
+    }
+
     @AfterAll
     public static void tearDown() {
         seaTunnelWebCluster.stop();


### PR DESCRIPTION
Added DELETE /seatunnel/api/v1/job/executor/delete API and called this API from UI code 
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

## Check list

* [ ] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
