### PR TITLE
[Bug][Seatunnel-web] Escape seatunnel-web placeholders

### DIFF
--- a/README_CN.md
+++ b/README_CN.md
@@ -73,7 +73,7 @@ sh build.sh code
 #### 2.4 配置应用程序并运行SeaTunnel Web后端服务器
 
 1. 编辑 `seatunnel-server/seatunnel-app/src/main/resources/application.yml` 写数据库连接信息
-2. 编辑 `apache-seatunnel-web-${project.version}/conf/application.yml` 文件,填写jwt.secretKey密钥,例如：https://github.com/apache/seatunnel(注意不要太短)。
+2. 编辑 `apache-seatunnel-web-${project.version}/conf/application.yml` 文件,填写jwt.secretKey密钥,例如：https://github.com/apache/seatunnel (注意不要太短)。
 
 ![img.png](docs/images/application_config.png)
 
@@ -173,7 +173,7 @@ tar -zxvf apache-seatunnel-web-${project.version}.tar.gz
 #### 3.5 配置应用并运行 SeaTunnel Web 后端服务
 
 * 编辑 `apache-seatunnel-web-${project.version}/conf/application.yml` 在文件中填写数据库连接信息和数据服务接口相关信息。
-* 编辑 `apache-seatunnel-web-${project.version}/conf/application.yml` 文件,填写jwt.secretKey密钥,例如：https://github.com/apache/seatunnel(注意不要太短)。
+* 编辑 `apache-seatunnel-web-${project.version}/conf/application.yml` 文件,填写jwt.secretKey密钥,例如：https://github.com/apache/seatunnel (注意不要太短)。
 
 ![image](docs/images/application_config.png)
 

--- a/seatunnel-server/seatunnel-app/src/main/java/org/apache/seatunnel/app/thirdparty/framework/SeaTunnelOptionRuleWrapper.java
+++ b/seatunnel-server/seatunnel-app/src/main/java/org/apache/seatunnel/app/thirdparty/framework/SeaTunnelOptionRuleWrapper.java
@@ -27,6 +27,7 @@ import org.apache.seatunnel.app.dynamicforms.FormLocale;
 import org.apache.seatunnel.app.dynamicforms.FormOptionBuilder;
 import org.apache.seatunnel.app.dynamicforms.FormStructure;
 import org.apache.seatunnel.app.dynamicforms.FormStructureBuilder;
+import org.apache.seatunnel.app.dynamicforms.PlaceholderUtil;
 import org.apache.seatunnel.app.dynamicforms.validate.ValidateBuilder;
 import org.apache.seatunnel.common.constants.PluginType;
 
@@ -95,6 +96,17 @@ public class SeaTunnelOptionRuleWrapper {
         formStructureBuilder.withLocale(locale);
 
         return FormOptionSort.sortFormStructure(formStructureBuilder.build());
+    }
+
+    private static Object getDefaultValue(Option<?> option) {
+        Object defValue = option.defaultValue();
+        if (defValue == null) {
+            return null;
+        }
+        if (String.class.equals(option.typeReference().getType())) {
+            return PlaceholderUtil.escapePlaceholders(defValue.toString());
+        }
+        return defValue;
     }
 
     private static List<AbstractFormOption> wrapperOptionOptions(
@@ -401,10 +413,7 @@ public class SeaTunnelOptionRuleWrapper {
         AbstractFormOption abstractFormOption =
                 staticSelectOptionBuilder
                         .formStaticSelectOption()
-                        .withDefaultValue(
-                                option.defaultValue() == null
-                                        ? null
-                                        : option.defaultValue().toString());
+                        .withDefaultValue(getDefaultValue(option));
 
         String placeholderI18nOptionKey = i18nOptionKey + "_description";
         if (enableLabelI18n(connectorName, placeholderI18nOptionKey, locale)) {
@@ -457,7 +466,7 @@ public class SeaTunnelOptionRuleWrapper {
                 builder.withField(option.key())
                         .inputOptionBuilder()
                         .formTextInputOption()
-                        .withDefaultValue(option.defaultValue());
+                        .withDefaultValue(getDefaultValue(option));
         if (enableLabelI18n(connectorName, placeholderI18nOptionKey, locale)) {
             abstractFormOption = abstractFormOption.withI18nPlaceholder(placeholderI18nOptionKey);
         } else {
@@ -484,7 +493,7 @@ public class SeaTunnelOptionRuleWrapper {
                         .inputOptionBuilder()
                         .formTextareaInputOption()
                         .withClearable()
-                        .withDefaultValue(option.defaultValue());
+                        .withDefaultValue(getDefaultValue(option));
         if (enableLabelI18n(connectorName, placeholderI18nOptionKey, locale)) {
             abstractFormOption = abstractFormOption.withI18nPlaceholder(placeholderI18nOptionKey);
         } else {

--- a/seatunnel-server/seatunnel-app/src/test/java/org/apache/seatunnel/app/utils/JobUtilsTests.java
+++ b/seatunnel-server/seatunnel-app/src/test/java/org/apache/seatunnel/app/utils/JobUtilsTests.java
@@ -109,6 +109,22 @@ public class JobUtilsTests {
         assertNotNull(config);
     }
 
+    @Test
+    public void testEscapedPlaceholderValuesNotReplaced() {
+        String jobConfigContent =
+                "job.mode=\\${jobModeParam:BATCH}\ncheckpoint.interval=\\\\${checkParam:30}\njob.name=${jobNameParam}";
+        Map<String, String> paramValues = new HashMap<>();
+        paramValues.put("jobModeParam", "STREAMING");
+        paramValues.put("jobNameParam", "newJob");
+        JobExecParam jobExecParam = getJobExecParam(paramValues);
+
+        String expected =
+                "job.mode=${jobModeParam:BATCH}\ncheckpoint.interval=${checkParam:30}\njob.name=newJob";
+        String actual = JobUtils.replaceJobConfigPlaceholders(jobConfigContent, jobExecParam);
+
+        assertEquals(expected, actual);
+    }
+
     private JobExecParam getJobExecParam(Map<String, String> paramValues) {
         JobExecParam jobExecParam = new JobExecParam();
         jobExecParam.setPlaceholderValues(paramValues);

--- a/seatunnel-server/seatunnel-dynamicform/src/main/java/org/apache/seatunnel/app/dynamicforms/PlaceholderUtil.java
+++ b/seatunnel-server/seatunnel-dynamicform/src/main/java/org/apache/seatunnel/app/dynamicforms/PlaceholderUtil.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seatunnel.app.dynamicforms;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class PlaceholderUtil {
+
+    private static final Pattern placeholderPattern =
+            Pattern.compile("(?<!\\\\)\\$\\{(\\w+)(?::(.*?))?\\}");
+
+    /**
+     * To replace ${paramName:defaultValue} or ${paramName} with \${paramName:defaultValue} and
+     * \${paramName} respectively.
+     *
+     * @param input the input string
+     * @return the input string with placeholders escaped
+     */
+    public static String escapePlaceholders(String input) {
+        Matcher matcher = placeholderPattern.matcher(input);
+        StringBuffer result = new StringBuffer();
+
+        while (matcher.find()) {
+            String placeholder = matcher.group();
+            matcher.appendReplacement(result, Matcher.quoteReplacement("\\" + placeholder));
+        }
+
+        matcher.appendTail(result);
+        return result.toString();
+    }
+}

--- a/seatunnel-server/seatunnel-dynamicform/src/test/java/org/apache/seatunnel/app/dynamicforms/PlaceholderUtilTest.java
+++ b/seatunnel-server/seatunnel-dynamicform/src/test/java/org/apache/seatunnel/app/dynamicforms/PlaceholderUtilTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seatunnel.app.dynamicforms;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class PlaceholderUtilTest {
+
+    @Test
+    public void testEscapePlaceholders() {
+        String input = "This is a test string with ${paramName:defaultValue} and ${paramName}.";
+        String expectedOutput =
+                "This is a test string with \\${paramName:defaultValue} and \\${paramName}.";
+        String actualOutput = PlaceholderUtil.escapePlaceholders(input);
+        assertEquals(expectedOutput, actualOutput);
+    }
+
+    @Test
+    public void testEscapePlaceholdersWithNoPlaceholders() {
+        String input = "This is a test string with no placeholders.";
+        String expectedOutput = "This is a test string with no placeholders.";
+        String actualOutput = PlaceholderUtil.escapePlaceholders(input);
+        assertEquals(expectedOutput, actualOutput);
+    }
+
+    @Test
+    public void testEscapePlaceholdersWithEscapedPlaceholders() {
+        String input = "This is a test string with \\${paramName:defaultValue} and \\${paramName}.";
+        String expectedOutput =
+                "This is a test string with \\${paramName:defaultValue} and \\${paramName}.";
+        String actualOutput = PlaceholderUtil.escapePlaceholders(input);
+        assertEquals(expectedOutput, actualOutput);
+    }
+
+    @Test
+    public void testEscapePlaceholdersWithMixedPlaceholders() {
+        String input =
+                "This is a test string with ${paramName:defaultValue}, \\${paramName}, and ${anotherParam}.";
+        String expectedOutput =
+                "This is a test string with \\${paramName:defaultValue}, \\${paramName}, and \\${anotherParam}.";
+        String actualOutput = PlaceholderUtil.escapePlaceholders(input);
+        assertEquals(expectedOutput, actualOutput);
+    }
+}


### PR DESCRIPTION
1. An option to escape placeholders in the configuration has been provided. 
2. If a placeholder is escaped by adding a backslash (e.g., \${valueParam:defaultValue}), it is passed to the Seatunnel engine as-is without value being replaced in Seatunnel-web. 
3. laceholders configured as default values in connectors are escaped before being displayed in the UI.

<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

## Check list

* [ ] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
