### PR TITLE
[Bug][Seatunnel-web] download_datasource.sh fails due to missing mvnw command

### DIFF
--- a/seatunnel-web-dist/src/main/assembly/seatunnel-web-ci.xml
+++ b/seatunnel-web-dist/src/main/assembly/seatunnel-web-ci.xml
@@ -70,6 +70,24 @@
             </includes>
             <outputDirectory>.</outputDirectory>
         </fileSet>
+        <!-- maven wrapper tools -->
+        <fileSet>
+            <directory>${basedir}/.././</directory>
+            <includes>
+                <include>mvnw</include>
+                <include>mvnw.cmd</include>
+            </includes>
+            <fileMode>0755</fileMode>
+            <outputDirectory>.</outputDirectory>
+        </fileSet>
+        <fileSet>
+            <directory>${basedir}/.././</directory>
+            <includes>
+                <include>.mvn/wrapper/maven-wrapper.properties</include>
+            </includes>
+            <fileMode>0755</fileMode>
+            <outputDirectory>.</outputDirectory>
+        </fileSet>
     </fileSets>
     <dependencySets>
         <!-- =================== Third party dependency =========================  -->

--- a/seatunnel-web-dist/src/main/assembly/seatunnel-web.xml
+++ b/seatunnel-web-dist/src/main/assembly/seatunnel-web.xml
@@ -71,6 +71,24 @@
             </includes>
             <outputDirectory>.</outputDirectory>
         </fileSet>
+        <!-- maven wrapper tools -->
+        <fileSet>
+            <directory>${basedir}/.././</directory>
+            <includes>
+                <include>mvnw</include>
+                <include>mvnw.cmd</include>
+            </includes>
+            <fileMode>0755</fileMode>
+            <outputDirectory>.</outputDirectory>
+        </fileSet>
+        <fileSet>
+            <directory>${basedir}/.././</directory>
+            <includes>
+                <include>.mvn/wrapper/maven-wrapper.properties</include>
+            </includes>
+            <fileMode>0755</fileMode>
+            <outputDirectory>.</outputDirectory>
+        </fileSet>
     </fileSets>
     <dependencySets>
         <dependencySet>


### PR DESCRIPTION
Copied mvnw,  mvnw.cmd and .mvn/wrapper/maven-wrapper.properties to seatunnel artifact
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

## Check list

* [ ] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
