### PR TITLE
[Bug] [Seatunnel-web] Fix  status always not runnning

### DIFF
--- a/seatunnel-server/seatunnel-app/src/main/bin/seatunnel-backend-daemon.sh
+++ b/seatunnel-server/seatunnel-app/src/main/bin/seatunnel-backend-daemon.sh
@@ -74,7 +74,7 @@ stop() {
 
 #status
 status() {
-  pid=$(jcmd | grep -i 'seatunnel-app-.*jar' | grep -v grep | awk '{print $1}')
+  pid=$(jcmd | grep -i 'org.apache.seatunnel.app.SeatunnelApplication' | grep -v grep | awk '{print $1}')
   if [ -n "$pid" ]; then
     echo "seatunnel is running"
   else

--- a/seatunnel-server/seatunnel-app/src/main/bin/seatunnel-backend-daemon.sh
+++ b/seatunnel-server/seatunnel-app/src/main/bin/seatunnel-backend-daemon.sh
@@ -35,7 +35,7 @@ check() {
 
 # start
 start() {
-  echo "starting seatunnel..."
+  echo "starting seatunnel-web..."
 
   check
 
@@ -58,17 +58,17 @@ start() {
   -cp "$WORKDIR/../conf":"$WORKDIR/../libs/*":"$WORKDIR/../datasource/*" \
   $SPRING_OPTS \
   org.apache.seatunnel.app.SeatunnelApplication >> "${LOGDIR}/seatunnel.out" 2>&1 &
-  echo "seatunnel started"
+  echo "seatunnel-web started"
 }
 # stop
 stop() {
-  echo "stopping seatunnel..."
+  echo "stopping seatunnel-web..."
   pid=$(jcmd | grep -i 'org.apache.seatunnel.app.SeatunnelApplication' | grep -v grep | awk '{print $1}')
   if [ -n "$pid" ]; then
     kill -15 $pid
-    echo "seatunnel stopped"
+    echo "seatunnel-web stopped"
   else
-    echo "seatunnel is not running"
+    echo "seatunnel-web is not running"
   fi
 }
 
@@ -76,9 +76,9 @@ stop() {
 status() {
   pid=$(jcmd | grep -i 'org.apache.seatunnel.app.SeatunnelApplication' | grep -v grep | awk '{print $1}')
   if [ -n "$pid" ]; then
-    echo "seatunnel is running"
+    echo "seatunnel-web is running"
   else
-    echo "seatunnel is not running"
+    echo "seatunnel-web is not running"
   fi
 }
 


### PR DESCRIPTION
## Purpose of this pull request

Fix: The status of seatunnel-web returned by the script `seatunnel-backend-daemon.sh` is always "not running"

<img width="1003" alt="image" src="https://github.com/user-attachments/assets/b8d8e58a-dd03-4bb9-bb71-76af7b866221">


<img width="948" alt="image" src="https://github.com/user-attachments/assets/bbb8e322-520f-40fc-8981-eb8023cb9ebb">


## Check list

* [ ] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
