### PR TITLE
[feature] After run a task, jump to the task details page

### DIFF
--- a/seatunnel-ui/src/locales/en_US/project.ts
+++ b/seatunnel-ui/src/locales/en_US/project.ts
@@ -1099,6 +1099,8 @@ export default {
     sql_content_label_placeholder: 'please input the SQL statement',
     query_validate: 'please input the SQL statement',
     target_name_tips: 'Please enter or select table name'
+    start_success: 'Start success',
+    start_failed: 'Start failed'
   },
   synchronization_instance: {
     pipeline_id: 'Pipeline Id',

--- a/seatunnel-ui/src/locales/en_US/project.ts
+++ b/seatunnel-ui/src/locales/en_US/project.ts
@@ -1098,7 +1098,7 @@ export default {
     sql_content_label: 'SQL',
     sql_content_label_placeholder: 'please input the SQL statement',
     query_validate: 'please input the SQL statement',
-    target_name_tips: 'Please enter or select table name'
+    target_name_tips: 'Please enter or select table name',
     start_success: 'Start success',
     start_failed: 'Start failed'
   },

--- a/seatunnel-ui/src/locales/zh_CN/project.ts
+++ b/seatunnel-ui/src/locales/zh_CN/project.ts
@@ -1066,7 +1066,9 @@ export default {
     sql_content_label: 'SQL',
     sql_content_label_placeholder: '请输入SQL语句',
     query_validate: '请输入SQL语句',
-    target_name_tips: '请输入或选择表名(必填)'
+    target_name_tips: '请输入或选择表名(必填)',
+    start_success: '启动成功',
+    start_failed: '启动失败'
   },
   synchronization_instance: {
     pipeline_id: 'Pipeline ID',

--- a/seatunnel-ui/src/views/task/synchronization-definition/use-table.ts
+++ b/seatunnel-ui/src/views/task/synchronization-definition/use-table.ts
@@ -29,6 +29,7 @@ import type { Router } from 'vue-router'
 import type { JobType } from './dag/types'
 import { COLUMN_WIDTH_CONFIG } from '@/common/column-width-config'
 import { useTableLink } from '@/hooks'
+import { useMessage } from 'naive-ui'
 
 export function useTable() {
   const { t } = useI18n()
@@ -51,6 +52,8 @@ export function useTable() {
     DATA_REPLICA: 'whole_library_sync',
     DATA_INTEGRATION: 'data_integration'
   } as { [key in JobType]: string }
+
+  const message = useMessage()
 
   const createColumns = (variables: any) => {
     variables.columns = [
@@ -135,12 +138,17 @@ export function useTable() {
   }
 
   const handleRun = (row: any) => {
-    executeJob(row.id).then(() => {
-      getTableData({
-        pageSize: variables.pageSize,
-        pageNo: variables.page,
-        searchName: variables.searchName
+    executeJob(row.id).then((res: any) => {
+      message.success(t('project.synchronization_definition.start_success'))
+      router.push({
+        path: `/task/synchronization-instance/${row.id}`,
+        query: {
+          jobInstanceId: res,
+          taskName: row.name
+        }
       })
+    }).catch((error) => {
+      message.error(t('project.synchronization_definition.start_failed'))
     })
   }
 

--- a/seatunnel-ui/src/views/task/synchronization-definition/use-table.ts
+++ b/seatunnel-ui/src/views/task/synchronization-definition/use-table.ts
@@ -55,6 +55,8 @@ export function useTable() {
 
   const message = useMessage()
 
+  const loadingStates = ref(new Map())
+
   const createColumns = (variables: any) => {
     variables.columns = [
       {
@@ -103,10 +105,12 @@ export function useTable() {
               },
               icon: h(EditOutlined)
             },
-            
             {
               text: t('project.synchronization_definition.start'),
-              onClick: (row: any) => void handleRun(row),
+              onClick: (row: any) => {
+                if (loadingStates.value.get(row.id)) return
+                handleRun(row)
+              },
               icon: h(PlayCircleOutlined)
             },
             {
@@ -116,8 +120,7 @@ export function useTable() {
               popTips: t('security.token.delete_confirm')
             }
           ]
-        },
-        
+        }
       )
     ]
   }
@@ -138,6 +141,9 @@ export function useTable() {
   }
 
   const handleRun = (row: any) => {
+    // Prevent duplicate task submissions
+    loadingStates.value.set(row.id, true)
+   
     executeJob(row.id).then((res: any) => {
       message.success(t('project.synchronization_definition.start_success'))
       router.push({
@@ -149,6 +155,7 @@ export function useTable() {
       })
     }).catch((error) => {
       message.error(t('project.synchronization_definition.start_failed'))
+      loadingStates.value.set(row.id, false)
     })
   }
 


### PR DESCRIPTION
## Purpose of this pull request

After running a task currently, there is no operation. We should jump to the task details after creating a task, which is more convenient to use.

Optimization:
1. New feature: Prevent repeated task submission by continuous clicking.
2. After submitting a task, jump to the task details.

https://github.com/user-attachments/assets/c757c7f0-0c3e-4db5-a332-7a824fb9e07a



## Check list

* [ ] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
