### PR TITLE
[Improve] Modify the default number of days for query tasks.

### DIFF
--- a/seatunnel-ui/src/views/task/synchronization-instance/use-sync-task.ts
+++ b/seatunnel-ui/src/views/task/synchronization-instance/use-sync-task.ts
@@ -16,7 +16,7 @@
  */
 
 import { h, reactive, ref } from 'vue'
-import { endOfToday, format, startOfToday } from 'date-fns'
+import { endOfToday, format, startOfToday, subDays } from 'date-fns'
 import { useTableLink, useTableOperation } from '@/hooks'
 import {
   AlignLeftOutlined,
@@ -85,7 +85,7 @@ export function useSyncTask(syncTaskType = 'BATCH') {
     checkedRowKeys: [] as Array<RowKey>,
     buttonList: [],
     datePickerRange: [
-      format(startOfToday(), 'yyyy-MM-dd HH:mm:ss'),
+      format(subDays(startOfToday(), 30), 'yyyy-MM-dd HH:mm:ss'),
       format(endOfToday(), 'yyyy-MM-dd HH:mm:ss')
     ]
   })
@@ -295,7 +295,7 @@ export function useSyncTask(syncTaskType = 'BATCH') {
     variables.host = ''
     variables.stateType = null
     variables.datePickerRange = [
-      format(startOfToday(), 'yyyy-MM-dd HH:mm:ss'),
+      format(subDays(startOfToday(), 30), 'yyyy-MM-dd HH:mm:ss'),
       format(endOfToday(), 'yyyy-MM-dd HH:mm:ss')
     ]
   }


### PR DESCRIPTION
## Purpose of this pull request

In the "Synchronizing task instances" page, currently the default query is for tasks of the current day. Under normal circumstances, we need to view more data and set the default range to 30 days.

<img width="1428" alt="image" src="https://github.com/user-attachments/assets/1b83f0b3-ccd9-49fc-8519-fba4d69fd116" />

## Check list

* [ ] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
