### PR TITLE
[Bug] DuplicateKeyException encountered while retrieving the job execution history

### DIFF
--- a/seatunnel-server/seatunnel-app/src/main/java/org/apache/seatunnel/app/service/impl/JobMetricsServiceImpl.java
+++ b/seatunnel-server/seatunnel-app/src/main/java/org/apache/seatunnel/app/service/impl/JobMetricsServiceImpl.java
@@ -46,6 +46,7 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Service;
 
 import lombok.NonNull;
@@ -596,7 +597,12 @@ public class JobMetricsServiceImpl extends SeatunnelBaseServiceImpl implements I
         JobInstanceHistory byInstanceId =
                 jobInstanceHistoryDao.getByInstanceId(jobInstance.getId());
         if (byInstanceId == null) {
-            jobInstanceHistoryDao.insert(jobHistoryFromEngine);
+            try {
+                jobInstanceHistoryDao.insert(jobHistoryFromEngine);
+            } catch (DuplicateKeyException e) {
+                // Handle the race condition gracefully
+                jobInstanceHistoryDao.updateJobInstanceHistory(jobHistoryFromEngine);
+            }
         } else {
             jobInstanceHistoryDao.updateJobInstanceHistory(jobHistoryFromEngine);
         }


### PR DESCRIPTION
immediately after task execution start, task instance page is opened. For small jobs it is throwing following errors

2025-01-29 12:06:18.800 seatunnel WM-TVJM7KC4Y4 ERROR [tr:,sp:] [qtp431300939-38] [GlobalExceptionHandler.logError():78] -
### Error updating database.  Cause: java.sql.SQLIntegrityConstraintViolationException: Duplicate entry '16473878314272' for key 't_st_job_instance_history.PRIMARY'
### The error may exist in org/apache/seatunnel/app/dal/mapper/JobInstanceHistoryMapper.java (best guess)
### The error may involve org.apache.seatunnel.app.dal.mapper.JobInstanceHistoryMapper.insert-Inline
### The error occurred while setting parameters
### SQL: INSERT INTO t_st_job_instance_history  ( id, dag )  VALUES  ( ?, ? )
### Cause: java.sql.SQLIntegrityConstraintViolationException: Duplicate entry '16473878314272' for key 't_st_job_instance_history.PRIMARY'
; Duplicate entry '16473878314272' for key 't_st_job_instance_history.PRIMARY'; nested exception is java.sql.SQLIntegrityConstraintViolationException: Duplicate entry '16473878314272' for key 't_st_job_instance_history.PRIMARY'
org.springframework.dao.DuplicateKeyException:
### Error updating database.  Cause: java.sql.SQLIntegrityConstraintViolationException: Duplicate entry '16473878314272' for key 't_st_job_instance_history.PRIMARY'
### The error may exist in org/apache/seatunnel/app/dal/mapper/JobInstanceHistoryMapper.java (best guess)
### The error may involve org.apache.seatunnel.app.dal.mapper.JobInstanceHistoryMapper.insert-Inline
### The error occurred while setting parameters
### SQL: INSERT INTO t_st_job_instance_history  ( id, dag )  VALUES  ( ?, ? )
### Cause: java.sql.SQLIntegrityConstraintViolationException: Duplicate entry '16473878314272' for key 't_st_job_instance_history.PRIMARY'
; Duplicate entry '16473878314272' for key 't_st_job_instance_history.PRIMARY'; nested exception is java.sql.SQLIntegrityConstraintViolationException: Duplicate entry '16473878314272' for key 't_st_job_instance_history.PRIMARY'
	at org.springframework.jdbc.support.SQLErrorCodeSQLExceptionTranslator.doTranslate(SQLErrorCodeSQLExceptionTranslator.java:247)
	at org.springframework.jdbc.support.AbstractFallbackSQLExceptionTranslator.translate(AbstractFallbackSQLExceptionTranslator.java:70)
	at org.mybatis.spring.MyBatisExceptionTranslator.translateExceptionIfPossible(MyBatisExceptionTranslator.java:91)
	at org.mybatis.spring.SqlSessionTemplate$SqlSessionInterceptor.invoke(SqlSessionTemplate.java:441)
	at jdk.proxy2/jdk.proxy2.$Proxy85.insert(Unknown Source)
	at org.mybatis.spring.SqlSessionTemplate.insert(SqlSessionTemplate.java:272`
`

