### PR TITLE
[Feature] Add Support for encrypting config fields

### DIFF
--- a/seatunnel-server/seatunnel-app/src/main/java/org/apache/seatunnel/app/common/Constants.java
+++ b/seatunnel-server/seatunnel-app/src/main/java/org/apache/seatunnel/app/common/Constants.java
@@ -215,6 +215,7 @@ public final class Constants {
     public static final String COMMON_TASK_TYPE = "common";
 
     public static final String DEFAULT = "default";
+    public static final String ENCRYPTION_TYPE_NONE = "none";
     public static final String PASSWORD = "password";
     public static final String XXXXXX = "******";
     public static final String NULL = "NULL";
@@ -658,4 +659,5 @@ public final class Constants {
 
     public static final String AUTHENTICATION_PROVIDER_LDAP = "LDAP";
     public static final String AUTHENTICATION_PROVIDER_DB = "DB";
+    public static final String ENCRYPTION_IDENTIFIER_KEY = "shade.identifier";
 }

--- a/seatunnel-server/seatunnel-app/src/main/java/org/apache/seatunnel/app/config/EncryptionConfig.java
+++ b/seatunnel-server/seatunnel-app/src/main/java/org/apache/seatunnel/app/config/EncryptionConfig.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.app.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import lombok.Data;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.apache.seatunnel.app.common.Constants.ENCRYPTION_TYPE_NONE;
+
+@Data
+@Configuration
+@ConfigurationProperties(prefix = "seatunnel-web.datasource.encryption")
+public class EncryptionConfig {
+    private String type = ENCRYPTION_TYPE_NONE;
+    private Set<String> keysToEncrypt = new HashSet<>();
+}

--- a/seatunnel-server/seatunnel-app/src/main/java/org/apache/seatunnel/app/utils/ConfigShadeUtil.java
+++ b/seatunnel-server/seatunnel-app/src/main/java/org/apache/seatunnel/app/utils/ConfigShadeUtil.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.app.utils;
+
+import org.apache.seatunnel.app.config.EncryptionConfig;
+import org.apache.seatunnel.core.starter.utils.ConfigShadeUtils;
+import org.apache.seatunnel.server.common.SeatunnelErrorEnum;
+import org.apache.seatunnel.server.common.SeatunnelException;
+
+import org.apache.commons.lang3.StringUtils;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Map;
+
+import static org.apache.seatunnel.app.common.Constants.ENCRYPTION_TYPE_NONE;
+
+@Slf4j
+@Component
+public class ConfigShadeUtil {
+
+    @Autowired private EncryptionConfig encryptionConfig;
+
+    public void encryptData(Map<String, String> datasourceConfig) {
+        if (encryptionConfig.getType().equals(ENCRYPTION_TYPE_NONE)) {
+            return;
+        }
+        for (String key : encryptionConfig.getKeysToEncrypt()) {
+            String value = datasourceConfig.get(key);
+            if (StringUtils.isNotEmpty(value)) {
+                try {
+                    String processedValue =
+                            ConfigShadeUtils.encryptOption(encryptionConfig.getType(), value);
+                    datasourceConfig.replace(key, processedValue);
+                } catch (IllegalArgumentException ex) {
+                    log.error("encryption for key {} failed", key);
+                    throw new SeatunnelException(
+                            SeatunnelErrorEnum.ERROR_CONFIG,
+                            String.format(
+                                    "encryption failed for key: %s, check if the keys were persisted in expected format",
+                                    key),
+                            ex);
+                }
+            }
+        }
+    }
+
+    public void decryptData(Map<String, String> datasourceConfig) {
+        if (encryptionConfig.getType().equals(ENCRYPTION_TYPE_NONE)) {
+            return;
+        }
+        for (String key : encryptionConfig.getKeysToEncrypt()) {
+            String value = datasourceConfig.get(key);
+            if (StringUtils.isNotEmpty(value)) {
+                try {
+                    String processedValue =
+                            ConfigShadeUtils.decryptOption(encryptionConfig.getType(), value);
+                    datasourceConfig.replace(key, processedValue);
+                } catch (IllegalArgumentException ex) {
+                    log.error("decryption for key {} failed", key);
+                    throw new SeatunnelException(
+                            SeatunnelErrorEnum.ERROR_CONFIG,
+                            String.format(
+                                    "decryption failed for key: %s, check if the keys were persisted in expected format",
+                                    key),
+                            ex);
+                }
+            }
+        }
+    }
+}

--- a/seatunnel-server/seatunnel-app/src/main/resources/application.yml
+++ b/seatunnel-server/seatunnel-app/src/main/resources/application.yml
@@ -52,7 +52,13 @@ jwt:
   secretKey:
   algorithm: HS256
 
-
+seatunnel-web:
+  datasource:
+    encryption:
+      type: none
+      keys-to-encrypt:
+        - password
+        - auth
 ---
 spring:
   config:

--- a/seatunnel-web-it/src/test/resources/application.yml
+++ b/seatunnel-web-it/src/test/resources/application.yml
@@ -48,6 +48,14 @@ jwt:
   secretKey: https://github.com/apache/seatunnel
   algorithm: HS256
 
+seatunnel-web:
+  datasource:
+    encryption:
+      type: none
+      keys-to-encrypt:
+        - password
+        - auth
+
 ---
 spring:
   application:


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request

While writing intermediate config to submit job via seatunnel client, we are required to encrypt certain fields like password, auth, username

By Default no encryption would be done, to enable the encryption provide the following properties

```
seatunnel-web:
  datasource:
    encryption:
      type: your_encryption
      keys-to-encrypt:
        - password
        - auth
```

ref: https://seatunnel.apache.org/docs/2.3.9/connector-v2/Config-Encryption-Decryption/

## Check list

* [x] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
