### PR TITLE
[Improve] ElasticSearch service address configuration supports the following two formats

### DIFF
--- a/seatunnel-datasource/seatunnel-datasource-plugins/datasource-elasticsearch/src/main/java/org/apache/seatunnel/datasource/plugin/elasticsearch/client/EsRestClient.java
+++ b/seatunnel-datasource/seatunnel-datasource-plugins/datasource-elasticsearch/src/main/java/org/apache/seatunnel/datasource/plugin/elasticsearch/client/EsRestClient.java
@@ -46,6 +46,7 @@ import lombok.extern.slf4j.Slf4j;
 import javax.net.ssl.SSLContext;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -68,10 +69,13 @@ public class EsRestClient implements AutoCloseable {
 
     public static EsRestClient createInstance(Config pluginConfig) {
         try {
-            List<String> hosts =
-                    JsonUtils.toList(
-                            pluginConfig.getString(ElasticSearchOptionRule.HOSTS.key()),
-                            String.class);
+            List<String> hosts;
+            String hostsConfig = pluginConfig.getString(ElasticSearchOptionRule.HOSTS.key());
+            try {
+                hosts = JsonUtils.toList(hostsConfig, String.class);
+            } catch (RuntimeException e) {
+                hosts = Collections.singletonList(hostsConfig);
+            }
             Optional<String> username = Optional.empty();
             Optional<String> password = Optional.empty();
             if (pluginConfig.hasPath(ElasticSearchOptionRule.USERNAME.key())) {

--- a/seatunnel-server/seatunnel-app/src/main/resources/i18n_en.config
+++ b/seatunnel-server/seatunnel-app/src/main/resources/i18n_en.config
@@ -169,7 +169,7 @@ SqlServer-CDC {
 
 Elasticsearch {
     hosts = "Hosts"
-    hosts_description = "The HTTP port information in ElasticSearch is of type List, such as [\"127.0.0.1:9200\", \"127.0.0.2:9200\"]"
+    hosts_description = "The configuration of the ElasticSearch service address supports the following two formats:\n 1. Single-node mode: A single string, such as \"127.0.0.1:9200\". \n 2. Cluster mode: A JSON array string, such as [\"127.0.0.1:9200\", \"127.0.0.2:9200\"]."
     username = "Username"
     password = "Password"
     tls_verify_certificate = "Enable TLS Verify Certificate"

--- a/seatunnel-server/seatunnel-app/src/main/resources/i18n_zh.config
+++ b/seatunnel-server/seatunnel-app/src/main/resources/i18n_zh.config
@@ -169,7 +169,7 @@ SqlServer-CDC {
 
 Elasticsearch {
     hosts = "访问地址"
-    hosts_description = "ElasticSearch中HTTP端口信息，类型为List，如：[\"127.0.0.1:9200\",\"127.0.0.2:9200\"]"
+    hosts_description = "ElasticSearch服务地址配置，支持以下两种格式：\n 1. 单节点模式：单个字符串，如 \"127.0.0.1:9200\" \n 2. 集群模式：JSON数组字符串，如 [\"127.0.0.1:9200\",\"127.0.0.2:9200\"]"
     username = "用户名"
     password = "密码"
     tls_verify_certificate = "为HTTPS端点启用证书验证"


### PR DESCRIPTION
## Purpose of this pull request

ElasticSearch service address configuration supports the following two formats:
1. Single node mode: a single string, such as "127.0.0.1:9200"
2. Cluster mode: JSON array string, such as ["127.0.0.1:9200", "127.0.0.2:9200"]


## Check list

* [ ] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
